### PR TITLE
Avoid literal unicode in compat.py.

### DIFF
--- a/coreapi/__init__.py
+++ b/coreapi/__init__.py
@@ -6,7 +6,7 @@ from coreapi.exceptions import ParseError, TransportError, ErrorMessage
 from coreapi import codecs, history, transports
 
 
-__version__ = '1.21.0'
+__version__ = '1.21.1'
 __all__ = [
     'Array', 'Document', 'Link', 'Object', 'Error', 'Field',
     'ParseError', 'NotAcceptable', 'TransportError', 'ErrorMessage',

--- a/coreapi/compat.py
+++ b/coreapi/compat.py
@@ -9,7 +9,7 @@ __all__ = [
 try:
     import urlparse
 
-    string_types = (type(b''), type(u''))
+    string_types = (basestring,)
     text_type = unicode
     COMPACT_SEPARATORS = (b',', b':')
     VERBOSE_SEPARATORS = (b',', b': ')


### PR DESCRIPTION
Ensures that other packages that support 3.2 can import coreapi without error.
