### PR TITLE
Mutlipart uses `files` for all parameters.

### DIFF
--- a/coreapi/__init__.py
+++ b/coreapi/__init__.py
@@ -4,7 +4,7 @@ from coreapi.client import Client
 from coreapi.document import Array, Document, Link, Object, Error, Field
 
 
-__version__ = '1.32.0'
+__version__ = '1.32.1'
 __all__ = [
     'Array', 'Document', 'Link', 'Object', 'Error', 'Field',
     'Client',

--- a/coreapi/compat.py
+++ b/coreapi/compat.py
@@ -47,6 +47,12 @@ def force_bytes(string):
     return string
 
 
+def force_text(string):
+    if not isinstance(string, string_types):
+        return string.decode('utf-8')
+    return string
+
+
 try:
     import click
     console_style = click.style

--- a/coreapi/transports/http.py
+++ b/coreapi/transports/http.py
@@ -140,8 +140,10 @@ def _build_http_request(session, url, method, headers=None, encoding=None, param
             else:
                 opts['json'] = params.data
         elif encoding == 'multipart/form-data':
-            opts['data'] = params.data
-            opts['files'] = params.files
+            files = {}
+            files.update(params.data)
+            files.update(params.files)
+            opts['files'] = files
         elif encoding == 'application/x-www-form-urlencoded':
             opts['data'] = params.data
         elif encoding == 'application/octet-stream':

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -1,6 +1,7 @@
 # coding: utf-8
 from coreapi import Document, Link, Field
 from coreapi.codecs import CoreJSONCodec
+from coreapi.compat import force_text
 from coreapi.exceptions import TransportError
 from coreapi.transports import HTTPTransport
 from coreapi.utils import determine_transport
@@ -91,7 +92,8 @@ def test_get_with_path_parameter(monkeypatch, http):
 def test_post(monkeypatch, http):
     def mockreturn(self, request):
         codec = CoreJSONCodec()
-        content = codec.dump(Document(content={'data': json.loads(request.body)}))
+        body = force_text(request.body)
+        content = codec.dump(Document(content={'data': json.loads(body)}))
         return MockResponse(content)
 
     monkeypatch.setattr(requests.Session, 'send', mockreturn)


### PR DESCRIPTION
Ensures that multipart encodings when `multipart/form-data` is given as the encoding, even if no file inputs are passed.