### PR TITLE
Introduce a NamedTemporaryFile fallback.

### DIFF
--- a/coreapi/__init__.py
+++ b/coreapi/__init__.py
@@ -4,7 +4,7 @@ from coreapi.client import Client
 from coreapi.document import Array, Document, Link, Object, Error, Field
 
 
-__version__ = '2.0.8'
+__version__ = '2.0.9'
 __all__ = [
     'Array', 'Document', 'Link', 'Object', 'Error', 'Field',
     'Client',

--- a/coreapi/compat.py
+++ b/coreapi/compat.py
@@ -55,3 +55,9 @@ try:
 except ImportError:
     def console_style(text, **kwargs):
         return text
+
+
+try:
+    from tempfile import _TemporaryFileWrapper
+except ImportError:
+    _TemporaryFileWrapper = None


### PR DESCRIPTION
For when `_TemporaryFileWrapper` does not exist.

Closes #106