### PR TITLE
Version 2.1

### DIFF
--- a/coreapi/__init__.py
+++ b/coreapi/__init__.py
@@ -4,7 +4,7 @@ from coreapi.client import Client
 from coreapi.document import Array, Document, Link, Object, Error, Field
 
 
-__version__ = '2.0.9'
+__version__ = '2.0.10'
 __all__ = [
     'Array', 'Document', 'Link', 'Object', 'Error', 'Field',
     'Client',

--- a/coreapi/__init__.py
+++ b/coreapi/__init__.py
@@ -4,7 +4,7 @@ from coreapi.client import Client
 from coreapi.document import Array, Document, Link, Object, Error, Field
 
 
-__version__ = '2.0.10'
+__version__ = '2.1.0'
 __all__ = [
     'Array', 'Document', 'Link', 'Object', 'Error', 'Field',
     'Client',

--- a/coreapi/codecs/corejson.py
+++ b/coreapi/codecs/corejson.py
@@ -187,7 +187,13 @@ def _primative_to_document(data, base_url=None):
         title = _get_string(meta, 'title')
         description = _get_string(meta, 'description')
         content = _get_content(data, base_url=url)
-        return Document(url=url, title=title, description=description, content=content)
+        return Document(
+            url=url,
+            title=title,
+            description=description,
+            media_type='application/coreapi+json',
+            content=content
+        )
 
     if isinstance(data, dict) and data.get('_type') == 'error':
         # Error

--- a/coreapi/codecs/corejson.py
+++ b/coreapi/codecs/corejson.py
@@ -218,7 +218,8 @@ def _primative_to_document(data, base_url=None):
                 required=_get_bool(item, 'required'),
                 location=_get_string(item, 'location'),
                 type=_get_string(item, 'type'),
-                description=_get_string(item, 'description')
+                description=_get_string(item, 'description'),
+                example=item.get('example')
             )
             for item in fields if isinstance(item, dict)
         ]

--- a/coreapi/codecs/corejson.py
+++ b/coreapi/codecs/corejson.py
@@ -102,6 +102,8 @@ def _document_to_primative(node, base_url=None):
             meta['url'] = url
         if node.title:
             meta['title'] = node.title
+        if node.description:
+            meta['description'] = node.description
         if meta:
             ret['_meta'] = meta
 
@@ -138,6 +140,8 @@ def _document_to_primative(node, base_url=None):
             ret['encoding'] = node.encoding
         if node.transform:
             ret['transform'] = node.transform
+        if node.title:
+            ret['title'] = node.title
         if node.description:
             ret['description'] = node.description
         if node.fields:
@@ -181,8 +185,9 @@ def _primative_to_document(data, base_url=None):
         url = _get_string(meta, 'url')
         url = urlparse.urljoin(base_url, url)
         title = _get_string(meta, 'title')
+        description = _get_string(meta, 'description')
         content = _get_content(data, base_url=url)
-        return Document(url=url, title=title, content=content)
+        return Document(url=url, title=title, description=description, content=content)
 
     if isinstance(data, dict) and data.get('_type') == 'error':
         # Error
@@ -198,6 +203,7 @@ def _primative_to_document(data, base_url=None):
         action = _get_string(data, 'action')
         encoding = _get_string(data, 'encoding')
         transform = _get_string(data, 'transform')
+        title = _get_string(data, 'title')
         description = _get_string(data, 'description')
         fields = _get_list(data, 'fields')
         fields = [
@@ -212,7 +218,7 @@ def _primative_to_document(data, base_url=None):
         ]
         return Link(
             url=url, action=action, encoding=encoding, transform=transform,
-            description=description, fields=fields
+            title=title, description=description, fields=fields
         )
 
     elif isinstance(data, dict):

--- a/coreapi/document.py
+++ b/coreapi/document.py
@@ -72,7 +72,7 @@ class Document(itypes.Dict):
         self._data = {key: _to_immutable(value) for key, value in content.items()}
 
     def clone(self, data):
-        return self.__class__(self.url, self.title, data)
+        return self.__class__(self.url, self.title, self.description, self.media_type, data)
 
     def __iter__(self):
         items = sorted(self._data.items(), key=_key_sorting)

--- a/coreapi/document.py
+++ b/coreapi/document.py
@@ -49,13 +49,15 @@ class Document(itypes.Dict):
     Expresses the data that the client may access,
     and the actions that the client may perform.
     """
-    def __init__(self, url=None, title=None, content=None):
+    def __init__(self, url=None, title=None, description=None, content=None):
         content = {} if (content is None) else content
 
         if url is not None and not isinstance(url, string_types):
             raise TypeError("'url' must be a string.")
         if title is not None and not isinstance(title, string_types):
             raise TypeError("'title' must be a string.")
+        if description is not None and not isinstance(description, string_types):
+            raise TypeError("'description' must be a string.")
         if not isinstance(content, dict):
             raise TypeError("'content' must be a dict.")
         if any([not isinstance(key, string_types) for key in content.keys()]):
@@ -63,6 +65,7 @@ class Document(itypes.Dict):
 
         self._url = '' if (url is None) else url
         self._title = '' if (title is None) else title
+        self._description = '' if (description is None) else description
         self._data = {key: _to_immutable(value) for key, value in content.items()}
 
     def clone(self, data):
@@ -94,6 +97,10 @@ class Document(itypes.Dict):
     @property
     def title(self):
         return self._title
+
+    @property
+    def description(self):
+        return self._description
 
     @property
     def data(self):
@@ -163,7 +170,7 @@ class Link(itypes.Object):
     """
     Links represent the actions that a client may perform.
     """
-    def __init__(self, url=None, action=None, encoding=None, transform=None, description=None, fields=None):
+    def __init__(self, url=None, action=None, encoding=None, transform=None, title=None, description=None, fields=None):
         if (url is not None) and (not isinstance(url, string_types)):
             raise TypeError("Argument 'url' must be a string.")
         if (action is not None) and (not isinstance(action, string_types)):
@@ -172,6 +179,8 @@ class Link(itypes.Object):
             raise TypeError("Argument 'encoding' must be a string.")
         if (transform is not None) and (not isinstance(transform, string_types)):
             raise TypeError("Argument 'transform' must be a string.")
+        if (title is not None) and (not isinstance(title, string_types)):
+            raise TypeError("Argument 'title' must be a string.")
         if (description is not None) and (not isinstance(description, string_types)):
             raise TypeError("Argument 'description' must be a string.")
         if (fields is not None) and (not isinstance(fields, (list, tuple))):
@@ -186,6 +195,7 @@ class Link(itypes.Object):
         self._action = '' if (action is None) else action
         self._encoding = '' if (encoding is None) else encoding
         self._transform = '' if (transform is None) else transform
+        self._title = '' if (title is None) else title
         self._description = '' if (description is None) else description
         self._fields = () if (fields is None) else tuple([
             item if isinstance(item, Field) else Field(item, required=False, location='')
@@ -207,6 +217,10 @@ class Link(itypes.Object):
     @property
     def transform(self):
         return self._transform
+
+    @property
+    def title(self):
+        return self._title
 
     @property
     def description(self):

--- a/coreapi/document.py
+++ b/coreapi/document.py
@@ -36,8 +36,8 @@ def _key_sorting(item):
 
 # The field class, as used by Link objects:
 
-Field = namedtuple('Field', ['name', 'required', 'location', 'type', 'description'])
-Field.__new__.__defaults__ = (False, '', '', '')
+Field = namedtuple('Field', ['name', 'required', 'location', 'type', 'description', 'example'])
+Field.__new__.__defaults__ = (False, '', '', '', None)
 
 
 # The Core API primatives:

--- a/coreapi/document.py
+++ b/coreapi/document.py
@@ -49,7 +49,7 @@ class Document(itypes.Dict):
     Expresses the data that the client may access,
     and the actions that the client may perform.
     """
-    def __init__(self, url=None, title=None, description=None, content=None):
+    def __init__(self, url=None, title=None, description=None, media_type=None, content=None):
         content = {} if (content is None) else content
 
         if url is not None and not isinstance(url, string_types):
@@ -58,6 +58,8 @@ class Document(itypes.Dict):
             raise TypeError("'title' must be a string.")
         if description is not None and not isinstance(description, string_types):
             raise TypeError("'description' must be a string.")
+        if media_type is not None and not isinstance(media_type, string_types):
+            raise TypeError("'media_type' must be a string.")
         if not isinstance(content, dict):
             raise TypeError("'content' must be a dict.")
         if any([not isinstance(key, string_types) for key in content.keys()]):
@@ -66,6 +68,7 @@ class Document(itypes.Dict):
         self._url = '' if (url is None) else url
         self._title = '' if (title is None) else title
         self._description = '' if (description is None) else description
+        self._media_type = '' if (media_type is None) else media_type
         self._data = {key: _to_immutable(value) for key, value in content.items()}
 
     def clone(self, data):
@@ -101,6 +104,10 @@ class Document(itypes.Dict):
     @property
     def description(self):
         return self._description
+
+    @property
+    def media_type(self):
+        return self._media_type
 
     @property
     def data(self):


### PR DESCRIPTION
Adds various backwards compatible attributes, based on requirements for rendering Document models into API documentation...

* `Document.description`
* `Document.media_type`
* `Link.title`
* `Field.example`

There will likely be more incoming based on the same set of requirements, ie...

Auth annotations, Ordered content, Sections, Response annotations, Indicate default values for parameters.