### PR TITLE
Fix unused deprecated auth

### DIFF
--- a/coreapi/transports/http.py
+++ b/coreapi/transports/http.py
@@ -349,7 +349,8 @@ class HTTPTransport(BaseTransport):
                 "The 'credentials' argument is now deprecated in favor of 'auth'.",
                 DeprecationWarning
             )
-            auth = DomainCredentials(credentials)
+            if session.auth is None:
+                session.auth = DomainCredentials(credentials)
         if request_callback is not None or response_callback is not None:
             warnings.warn(
                 "The 'request_callback' and 'response_callback' arguments are now deprecated. "


### PR DESCRIPTION
The depreciation broke the current implementations like coreapi-cli 1.0.6 whose credentials aren't sent anymore.