### PR TITLE
Fixes erroneous assignment of legacy credentials.

### DIFF
--- a/coreapi/transports/http.py
+++ b/coreapi/transports/http.py
@@ -349,7 +349,7 @@ class HTTPTransport(BaseTransport):
                 "The 'credentials' argument is now deprecated in favor of 'auth'.",
                 DeprecationWarning
             )
-            auth = DomainCredentials(credentials)
+            session.auth = DomainCredentials(credentials)
         if request_callback is not None or response_callback is not None:
             warnings.warn(
                 "The 'request_callback' and 'response_callback' arguments are now deprecated. "


### PR DESCRIPTION
With the introduction of auth schemes in 2.3.0, the `DomainCredentials` object was introduced to support the legacy `credentials` parameter (e.g., requests sent from `coreapi-cli`); however, code paths in `HttpTransport` did not properly set `session.auth` to this generated wrapper.

Refs: a91c765
Refs: 2.3.0