### PR TITLE
Descriptions of path fields and form fields default same value

### DIFF
--- a/coreapi/document.py
+++ b/coreapi/document.py
@@ -47,7 +47,7 @@ def _key_sorting(item):
 # NOTE: 'type', 'description' and 'example' are now deprecated,
 #       in favor of 'schema'.
 Field = namedtuple('Field', ['name', 'required', 'location', 'schema', 'description', 'type', 'example'])
-Field.__new__.__defaults__ = (False, '', None, None, None, None)
+Field.__new__.__defaults__ = (False, '', None, '', None, None)
 
 
 # The Core API primitives:


### PR DESCRIPTION
… fields defaults to "". This results in inconsistent presentation. This commit changes path fields default to "".

Example before change:
"/example-movies/v1/{id}/": {"put": {"description": "Updates the movie with passed movie id.", "parameters": [{"description": null, "required": true, "type": "string", "name": "id", "in": "path"}, {"description": "", "required": true, "type": "string", "name": "title", "in": "formData"}, {"description": "", "required": true, "type": "integer", "name": "rating", "in": "formData"}], "tags": ["example-movies"], "summary": "Updates the movie with passed movie id.", "operationId": "example-movies_v1_update", "consumes": ["application/x-www-form-urlencoded"], "responses": {"200": {"description": ""}}},
Example after change:
"/example-movies/v1/{id}/": {"put": {"description": "Updates the movie with passed movie id.", "parameters": [{"description": "", "required": true, "type": "string", "name": "id", "in": "path"}, {"description": "", "required": true, "type": "string", "name": "title", "in": "formData"}, {"description": "", "required": true, "type": "integer", "name": "rating", "in": "formData"}], "tags": ["example-movies"], "summary": "Updates the movie with passed movie id.", "operationId": "example-movies_v1_update", "consumes": ["application/x-www-form-urlencoded"], "responses": {"200": {"description": ""}}}
Description of id field changed to be consistent with title and rating fields' descriptions.