### PR TITLE
Merge environment settings for SSL requests

### DIFF
--- a/coreapi/transports/http.py
+++ b/coreapi/transports/http.py
@@ -376,7 +376,8 @@ class HTTPTransport(BaseTransport):
         headers.update(self.headers)
 
         request = _build_http_request(session, url, method, headers, encoding, params)
-        response = session.send(request)
+        settings = session.merge_environment_settings(request.url, None, None, None, None)
+        response = session.send(request, **settings)
         result = _decode_result(response, decoders, force_codec)
 
         if isinstance(result, Document) and link_ancestors:

--- a/tests/test_integration.py
+++ b/tests/test_integration.py
@@ -41,7 +41,7 @@ def test_dump(document):
 
 
 def test_get(monkeypatch):
-    def mockreturn(self, request):
+    def mockreturn(self, request, *args, **kwargs):
         return MockResponse(b'{"_type": "document", "example": 123}')
 
     monkeypatch.setattr(requests.Session, 'send', mockreturn)
@@ -52,7 +52,7 @@ def test_get(monkeypatch):
 
 
 def test_follow(monkeypatch, document):
-    def mockreturn(self, request):
+    def mockreturn(self, request, *args, **kwargs):
         return MockResponse(b'{"_type": "document", "example": 123}')
 
     monkeypatch.setattr(requests.Session, 'send', mockreturn)
@@ -63,7 +63,7 @@ def test_follow(monkeypatch, document):
 
 
 def test_reload(monkeypatch):
-    def mockreturn(self, request):
+    def mockreturn(self, request, *args, **kwargs):
         return MockResponse(b'{"_type": "document", "example": 123}')
 
     monkeypatch.setattr(requests.Session, 'send', mockreturn)
@@ -75,7 +75,7 @@ def test_reload(monkeypatch):
 
 
 def test_error(monkeypatch, document):
-    def mockreturn(self, request):
+    def mockreturn(self, request, *args, **kwargs):
         return MockResponse(b'{"_type": "error", "message": ["failed"]}')
 
     monkeypatch.setattr(requests.Session, 'send', mockreturn)

--- a/tests/test_transport.py
+++ b/tests/test_transport.py
@@ -47,7 +47,7 @@ def test_missing_hostname():
 # Test basic transition types.
 
 def test_get(monkeypatch, http):
-    def mockreturn(self, request):
+    def mockreturn(self, request, *args, **kwargs):
         return MockResponse(b'{"_type": "document", "example": 123}')
 
     monkeypatch.setattr(requests.Session, 'send', mockreturn)
@@ -58,7 +58,7 @@ def test_get(monkeypatch, http):
 
 
 def test_get_with_parameters(monkeypatch, http):
-    def mockreturn(self, request):
+    def mockreturn(self, request, *args, **kwargs):
         insert = request.path_url.encode('utf-8')
         return MockResponse(
             b'{"_type": "document", "url": "' + insert + b'"}'
@@ -72,7 +72,7 @@ def test_get_with_parameters(monkeypatch, http):
 
 
 def test_get_with_path_parameter(monkeypatch, http):
-    def mockreturn(self, request):
+    def mockreturn(self, request, *args, **kwargs):
         insert = request.url.encode('utf-8')
         return MockResponse(
             b'{"_type": "document", "example": "' + insert + b'"}'
@@ -90,7 +90,7 @@ def test_get_with_path_parameter(monkeypatch, http):
 
 
 def test_post(monkeypatch, http):
-    def mockreturn(self, request):
+    def mockreturn(self, request, *args, **kwargs):
         codec = CoreJSONCodec()
         body = force_text(request.body)
         content = codec.encode(Document(content={'data': json.loads(body)}))
@@ -104,7 +104,7 @@ def test_post(monkeypatch, http):
 
 
 def test_delete(monkeypatch, http):
-    def mockreturn(self, request):
+    def mockreturn(self, request, *args, **kwargs):
         return MockResponse(b'')
 
     monkeypatch.setattr(requests.Session, 'send', mockreturn)


### PR DESCRIPTION
When using requests' builder, we bypass the environment settings,
which include information about SSL certificates. This makes requests
to a SSL endpoint fail.
This commit adds a call to `session.merge_environment_settings` to fix
this issue, and updates the test suite accordingly.

cf #152.