### PR TITLE
Version 3

### DIFF
--- a/coreapi/client.py
+++ b/coreapi/client.py
@@ -131,18 +131,7 @@ class Client(itypes.Object):
         # Fallback for v1.x. To be removed in favour of explict `get` style.
         return self.get(document.url, format=format, force_codec=force_codec)
 
-    def action(self, document, keys, params=None, validate=True, overrides=None,
-               action=None, encoding=None):
-        if (action is not None) or (encoding is not None):
-            # Fallback for v1.x overrides.
-            # Will be removed at some point, most likely in a 2.1 release.
-            if overrides is None:
-                overrides = {}
-            if action is not None:
-                overrides['action'] = action
-            if encoding is not None:
-                overrides['encoding'] = encoding
-
+    def action(self, document, keys, params=None, validate=True, overrides=None):
         if isinstance(keys, string_types):
             keys = [keys]
 

--- a/coreapi/codecs/corejson.py
+++ b/coreapi/codecs/corejson.py
@@ -196,8 +196,6 @@ def _document_to_primitive(node, base_url=None):
             ret['action'] = node.action
         if node.encoding:
             ret['encoding'] = node.encoding
-        if node.transform:
-            ret['transform'] = node.transform
         if node.title:
             ret['title'] = node.title
         if node.description:
@@ -264,7 +262,6 @@ def _primitive_to_document(data, base_url=None):
         url = urlparse.urljoin(base_url, url)
         action = _get_string(data, 'action')
         encoding = _get_string(data, 'encoding')
-        transform = _get_string(data, 'transform')
         title = _get_string(data, 'title')
         description = _get_string(data, 'description')
         fields = _get_list(data, 'fields')
@@ -278,7 +275,7 @@ def _primitive_to_document(data, base_url=None):
             for item in fields if isinstance(item, dict)
         ]
         return Link(
-            url=url, action=action, encoding=encoding, transform=transform,
+            url=url, action=action, encoding=encoding,
             title=title, description=description, fields=fields
         )
 

--- a/coreapi/codecs/python.py
+++ b/coreapi/codecs/python.py
@@ -42,8 +42,6 @@ def _to_repr(node):
             args += ", action=%s" % repr(node.action)
         if node.encoding:
             args += ", encoding=%s" % repr(node.encoding)
-        if node.transform:
-            args += ", transform=%s" % repr(node.transform)
         if node.description:
             args += ", description=%s" % repr(node.description)
         if node.fields:

--- a/coreapi/document.py
+++ b/coreapi/document.py
@@ -187,15 +187,13 @@ class Link(itypes.Object):
     """
     Links represent the actions that a client may perform.
     """
-    def __init__(self, url=None, action=None, encoding=None, transform=None, title=None, description=None, fields=None):
+    def __init__(self, url=None, action=None, encoding=None, title=None, description=None, fields=None):
         if (url is not None) and (not isinstance(url, string_types)):
             raise TypeError("Argument 'url' must be a string.")
         if (action is not None) and (not isinstance(action, string_types)):
             raise TypeError("Argument 'action' must be a string.")
         if (encoding is not None) and (not isinstance(encoding, string_types)):
             raise TypeError("Argument 'encoding' must be a string.")
-        if (transform is not None) and (not isinstance(transform, string_types)):
-            raise TypeError("Argument 'transform' must be a string.")
         if (title is not None) and (not isinstance(title, string_types)):
             raise TypeError("Argument 'title' must be a string.")
         if (description is not None) and (not isinstance(description, string_types)):
@@ -211,7 +209,6 @@ class Link(itypes.Object):
         self._url = '' if (url is None) else url
         self._action = '' if (action is None) else action
         self._encoding = '' if (encoding is None) else encoding
-        self._transform = '' if (transform is None) else transform
         self._title = '' if (title is None) else title
         self._description = '' if (description is None) else description
         self._fields = () if (fields is None) else tuple([
@@ -232,10 +229,6 @@ class Link(itypes.Object):
         return self._encoding
 
     @property
-    def transform(self):
-        return self._transform
-
-    @property
     def title(self):
         return self._title
 
@@ -253,7 +246,6 @@ class Link(itypes.Object):
             self.url == other.url and
             self.action == other.action and
             self.encoding == other.encoding and
-            self.transform == other.transform and
             self.description == other.description and
             sorted(self.fields, key=lambda f: f.name) == sorted(other.fields, key=lambda f: f.name)
         )

--- a/coreapi/transports/http.py
+++ b/coreapi/transports/http.py
@@ -308,7 +308,7 @@ def _decode_result(response, decoders, force_codec=False):
 class HTTPTransport(BaseTransport):
     schemes = ['http', 'https']
 
-    def __init__(self, credentials=None, headers=None, auth=None, session=None, request_callback=None, response_callback=None):
+    def __init__(self, headers=None, auth=None, session=None, request_callback=None, response_callback=None):
         if headers:
             headers = {key.lower(): value for key, value in headers.items()}
         if session is None:
@@ -318,12 +318,6 @@ class HTTPTransport(BaseTransport):
         if not getattr(session.auth, 'allow_cookies', False):
             session.cookies.set_policy(BlockAll())
 
-        if credentials is not None:
-            warnings.warn(
-                "The 'credentials' argument is now deprecated in favor of 'auth'.",
-                DeprecationWarning
-            )
-            auth = DomainCredentials(credentials)
         if request_callback is not None or response_callback is not None:
             warnings.warn(
                 "The 'request_callback' and 'response_callback' arguments are now deprecated. "

--- a/coreapi/transports/http.py
+++ b/coreapi/transports/http.py
@@ -308,7 +308,7 @@ def _decode_result(response, decoders, force_codec=False):
 class HTTPTransport(BaseTransport):
     schemes = ['http', 'https']
 
-    def __init__(self, headers=None, auth=None, session=None, request_callback=None, response_callback=None):
+    def __init__(self, headers=None, auth=None, session=None):
         if headers:
             headers = {key.lower(): value for key, value in headers.items()}
         if session is None:
@@ -317,15 +317,6 @@ class HTTPTransport(BaseTransport):
             session.auth = auth
         if not getattr(session.auth, 'allow_cookies', False):
             session.cookies.set_policy(BlockAll())
-
-        if request_callback is not None or response_callback is not None:
-            warnings.warn(
-                "The 'request_callback' and 'response_callback' arguments are now deprecated. "
-                "Use a custom 'session' instance instead.",
-                DeprecationWarning
-            )
-            session.mount('https://', CallbackAdapter(request_callback, response_callback))
-            session.mount('http://', CallbackAdapter(request_callback, response_callback))
 
         self._headers = itypes.Dict(headers or {})
         self._session = session

--- a/tests/test_codecs.py
+++ b/tests/test_codecs.py
@@ -194,7 +194,6 @@ def test_link_encodings(json_codec):
     doc = Document(content={
         'link': Link(
             action='post',
-            transform='inplace',
             fields=['optional', Field('required', required=True, location='path')]
         )
     })
@@ -204,7 +203,6 @@ def test_link_encodings(json_codec):
     "link": {
         "_type": "link",
         "action": "post",
-        "transform": "inplace",
         "fields": [
             {
                 "name": "optional"

--- a/tests/test_document.py
+++ b/tests/test_document.py
@@ -17,7 +17,6 @@ def doc():
             'link': Link(
                 url='/',
                 action='post',
-                transform='inplace',
                 fields=['optional', Field('required', required=True, location='path')]
             ),
             'nested': {'child': Link(url='/123')}
@@ -224,7 +223,7 @@ def test_document_repr(doc):
         "'integer': 123, "
         "'list': [1, 2, 3], "
         "'nested': {'child': Link(url='/123')}, "
-        "'link': Link(url='/', action='post', transform='inplace', "
+        "'link': Link(url='/', action='post', "
         "fields=['optional', Field('required', required=True, location='path')])"
         "})"
     )
@@ -345,7 +344,6 @@ def test_document_equality(doc):
         'link': Link(
             url='/',
             action='post',
-            transform='inplace',
             fields=['optional', Field('required', required=True, location='path')]
         ),
         'nested': {'child': Link(url='/123')}
@@ -422,11 +420,6 @@ def test_link_url_must_be_string():
 def test_link_action_must_be_string():
     with pytest.raises(TypeError):
         Link(action=123)
-
-
-def test_link_transform_must_be_string():
-    with pytest.raises(TypeError):
-        Link(transform=123)
 
 
 def test_link_fields_must_be_list():


### PR DESCRIPTION
Drop deprecated arguments:

* Drop `transform` on Links and remove `inplace` transformations.
* Drop `action` and 'encoding' parameters on the Client, in favor of the general purpose `overrides`
* Drop `credentials` on HTTPTransport in favor of `auth`.
* Drop `request_callback`/`response_callback` on HTTPTransport in favor of custom sessions.